### PR TITLE
Use ProxyFromEnvironment when creating HTTP transport

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -25,21 +25,11 @@ import (
 
 // GeneralCAHttpClient returns an http.Client configured for general use
 func GeneralCAHttpClient() (*http.Client, error) {
-	httpClient := &http.Client{
-
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12, // Require TLS 1.2 or higher
-			},
-		},
-
-		// softlayer.go has been overriding http.DefaultClient and forcing 120s
-		// timeout on us, so we'll continue to force it on ourselves in case
-		// we've accidentally become acustomed to it.
-		Timeout: time.Second * 120,
-	}
-
-	return httpClient, nil
+	// softlayer.go has been overriding http.DefaultClient and forcing 120s
+	// timeout on us, so we'll continue to force it on ourselves in case
+	// we've accidentally become acustomed to it.
+	timeout := time.Second * 120
+	return GeneralCAHttpClientWithTimeout(timeout)
 }
 
 // GeneralCAHttpClientWithTimeout returns an http.Client configured for general use
@@ -47,6 +37,7 @@ func GeneralCAHttpClientWithTimeout(timeout time.Duration) (*http.Client, error)
 	httpClient := &http.Client{
 
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12, // Require TLS 1.2 or higher
 			},


### PR DESCRIPTION
This issue was discovered by OpenShift QE [OCPBUGS-18105](https://issues.redhat.com/browse/OCPBUGS-18105). One part of the problem was that the `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables were not set on the driver container -- this was fixed by https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/74

But after setting those environment variables, the driver was not actually using those proxy settings, and connections would still time out while attempting to provision a volume.

`
{"level":"error","ts":"2023-09-01T07:21:59.721Z","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"475fc498-6187-4248-9634-4501fd261c68","error":"{RequestID: 475fc498-6187-4248-9634-4501fd261c68 , Code: InternalError, Description: Internal error occurred%!(EXTRA string=creation), BackendError: {Code:FailedToPlaceOrder, Type:ProvisioningFailed, Description:Failed to create volume with the storage provider, BackendError:Post \"https://eu-gb.iaas.cloud.ibm.com/v1/volumes?generation=2&version=2019-07-02\": dial tcp 104.18.167.51:443: i/o timeout (Client.Timeout exceeded while awaiting headers), RC:500}, Action: Please check 'BackendError' tag for more details}"}
`

But `curl` from inside the container _did_ use those proxy variables.

The difference, compared to [AWS](https://github.com/aws/aws-sdk-go/blob/07a76fa4aedbed35c5efc68d9cd3e3f5dd33dea7/aws/session/custom_transport.go#L16) or [Azure](https://github.com/Azure/azure-sdk-for-go/blob/68baa6f9cc9838b3ff5f4ab7661f4330947674c1/sdk/azcore/runtime/transport_default_http_client.go#L20), is that we don't use `http.ProxyFromEnvironment` when setting up the HTTP transport in the connection used by the IBM driver.

This fix adds `http.ProxyFromEnvironment` when creating the transport, which resolves the issues we've seen with volume provisioning after [setting the cluster-wide proxy on OpenShift](https://docs.openshift.com/container-platform/4.13/networking/enable-cluster-wide-proxy.html).

/cc @ambiknai @arahamad-zz @GunaKKIBM

